### PR TITLE
change join import to path default import for mjs compatibility

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import path from 'path';
 const _ = Cypress._;
 
 const methods = [
@@ -83,7 +83,7 @@ function parseUrl(url) {
             const protocol = split[0] + '://';
             const baseUrl = split[1];
 
-            url = protocol + join(baseUrl, url);
+            url = protocol + path.join(baseUrl, url);
         }
     }
     return url;


### PR DESCRIPTION
The current version of the library fails to run due to an invalid import when the mjs version is used. The bundled es version copies the

```js
import { join } from 'path';
```

import verbatim. However, node interprets mjs files with a different set of rules. For commonjs interoperability, node only allows default imports, as explained in the [documentation](https://nodejs.org/api/esm.html#esm_code_import_code_statements). Because of that, upon running cypress with cypress-commands, we get:

```bash
Oops...we found an error preparing this test file:

  src/support/index.ts

The error was:

/workspace/node_modules/cypress-commands/dist/cypress-commands.mjs 851:29-33
Can't import the named export 'join' from non EcmaScript module (only default export is available)
 @ ./src/support/index.ts
 @ multi ./src/support/index.ts
```

The solution is to change the named join import to a path default import:

```js
import path from 'path';
```

- [x] Tests
- [x] Documentation
- [x] Type definitions
- [x] Ready for merge
