### PR TITLE
Support for zero width whitespace and wbr tag

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -29,7 +29,7 @@
     <div class="whitespace" data-complex=" some&nbsp; &nbsp; &#x9; very
       complex&Tab;whitespace">
       div
-      containing&nbsp; &nbsp; &#x9; some<br> complex&Tab;whitespace
+      cont&ZeroWidthSpace;aining&nbsp; &nbsp; &#x9; some<br> complex&Tab;white<wbr>space
     </div>
     <hr>
     <div class="parent indent" data-relation="parent" data-foo>

--- a/app/index.html
+++ b/app/index.html
@@ -36,7 +36,7 @@
     </div>
     <hr>
     <div class="parent indent" data-relation="parent" data-foo>
-      parent div
+      parent div top
       <div class="child indent" data-relation="child">
         child div
         <div class="grandchild indent" data-relation="grandchild">
@@ -49,12 +49,14 @@
           </div>
         </div>
       </div>
-      <div class="secondchild indent" data-relation="child">
-        secondchild div
-        <div class="secondgrandchild indent">
-          secondgrandchild div
+      parent div middle
+      <div class="second-child indent" data-relation="child">
+        second-child div
+        <div class="second-grand-child indent">
+          second-grand-child div
         </div>
       </div>
+      parent div bottom
     </div>
   </body>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -31,6 +31,9 @@
       div
       cont&ZeroWidthSpace;aining&nbsp; &nbsp; &#x9; some<br> complex&Tab;white<wbr>space
     </div>
+    <div class="formatted">
+      S<i>om</i>e text <b>with </b>inline <span>for<abbr>mat</abbr>ting<br>applied to it.</span>
+    </div>
     <hr>
     <div class="parent indent" data-relation="parent" data-foo>
       parent div

--- a/cypress/integration/text.js
+++ b/cypress/integration/text.js
@@ -65,7 +65,7 @@ describe('The added command `text`', function() {
                 .should((texts) => {
                     expect(texts).to.be.lengthOf(2);
                     expect(texts[0]).to.equal('child div');
-                    expect(texts[1]).to.equal('secondchild div');
+                    expect(texts[1]).to.equal('second-child div');
                 });
         });
     });
@@ -74,33 +74,63 @@ describe('The added command `text`', function() {
         it('`0` is the default value', function() {
             cy.get('div.parent')
                 .text()
-                .should('equal', 'parent div');
+                .should('equal', [
+                    'parent div top',
+                    'parent div middle',
+                    'parent div bottom',
+                ].join(' '));
         });
 
         it('`0` results in only the contents of the element itself', function() {
             cy.get('div.parent')
                 .text({ depth: 0 })
-                .should('equal', 'parent div');
+                .should('equal', [
+                    'parent div top',
+                    'parent div middle',
+                    'parent div bottom',
+                ].join(' '));
         });
 
         it('`1` results in the contents of the element and its direct children', function() {
             cy.get('div.parent')
                 .text({ depth: 1 })
-                .should('equal', 'parent div child div secondchild div');
+                .should('equal', [
+                    'parent div top',
+                    'child div',
+                    'parent div middle',
+                    'second-child div',
+                    'parent div bottom',
+                ].join(' '));
         });
 
         it('`2` results in the contents of the element and its direct children', function() {
             cy.get('div.parent')
                 .text({ depth: 2 })
-                .should('equal', 'parent div child div grandchild div secondchild div '
-                    + 'secondgrandchild div');
+                .should('equal', [
+                    'parent div top',
+                    'child div',
+                    'grandchild div',
+                    'parent div middle',
+                    'second-child div',
+                    'second-grand-child div',
+                    'parent div bottom',
+                ].join(' '));
         });
 
         it('`Infinity` results in the contents of the element and all its children', function() {
             cy.get('div.parent')
                 .text({ depth: Infinity })
-                .should('equal', 'parent div child div grandchild div great-grandchild div '
-                    + 'great-great-grandchild div secondchild div secondgrandchild div');
+                .should('equal', [
+                    'parent div top',
+                    'child div',
+                    'grandchild div',
+                    'great-grandchild div',
+                    'great-great-grandchild div',
+                    'parent div middle',
+                    'second-child div',
+                    'second-grand-child div',
+                    'parent div bottom',
+                ].join(' '));
         });
 
         it('gets all values of form elements', function() {

--- a/cypress/integration/text.js
+++ b/cypress/integration/text.js
@@ -92,15 +92,15 @@ describe('The added command `text`', function() {
         it('`2` results in the contents of the element and its direct children', function() {
             cy.get('div.parent')
                 .text({ depth: 2 })
-                .should('equal', 'parent div child div secondchild div grandchild div '
+                .should('equal', 'parent div child div grandchild div secondchild div '
                     + 'secondgrandchild div');
         });
 
         it('`Infinity` results in the contents of the element and all its children', function() {
             cy.get('div.parent')
                 .text({ depth: Infinity })
-                .should('equal', 'parent div child div secondchild div grandchild div '
-                    + 'secondgrandchild div great-grandchild div great-great-grandchild div');
+                .should('equal', 'parent div child div grandchild div great-grandchild div '
+                    + 'great-great-grandchild div secondchild div secondgrandchild div');
         });
 
         it('gets all values of form elements', function() {
@@ -115,18 +115,30 @@ describe('The added command `text`', function() {
             cy.get('div.whitespace')
                 .text()
                 .should('equal', 'div containing some complex whitespace');
+
+            cy.get('div.formatted')
+                .text({ depth: 9 })
+                .should('equal', 'Some text with inline formatting applied to it.');
         });
 
         it('`simplify` simplifies all whitespace', function() {
             cy.get('div.whitespace')
                 .text({ whitespace: 'simplify' })
                 .should('equal', 'div containing some complex whitespace');
+
+            cy.get('div.formatted')
+                .text({ depth: 9, whitespace: 'simplify' })
+                .should('equal', 'Some text with inline formatting applied to it.');
         });
 
         it('`keep-newline` simplifies all whitespace except newlines', function() {
             cy.get('div.whitespace')
                 .text({ whitespace: 'keep-newline' })
                 .should('equal', 'div\ncontaining some complex whitespace');
+
+            cy.get('div.formatted')
+                .text({ depth: 9, whitespace: 'keep-newline' })
+                .should('equal', 'Some text with inline formatting applied to it.');
         });
 
         it('`keep` does not change whitespace at all', function() {
@@ -137,7 +149,14 @@ describe('The added command `text`', function() {
 
                     expect(lines[0]).to.equal('div');
                     expect(lines[1].trim())
-                        .to.equal('cont\u200Baining\xa0 \xa0 \t some complex\twhite\u200Bspace');
+                        .to.equal('cont\u200Baining\xa0 \xa0 \t some  complex\twhite\u200Bspace');
+                });
+
+            cy.get('div.formatted')
+                .text({ depth: 9, whitespace: 'keep' })
+                .should((text) => {
+                    expect(text.trim())
+                        .to.equal('Some text with inline formatting applied to it.');
                 });
         });
     });

--- a/cypress/integration/text.js
+++ b/cypress/integration/text.js
@@ -137,7 +137,7 @@ describe('The added command `text`', function() {
 
                     expect(lines[0]).to.equal('div');
                     expect(lines[1].trim())
-                        .to.equal('containing\xa0 \xa0 \t some complex\twhitespace');
+                        .to.equal('cont\u200Baining\xa0 \xa0 \t some complex\twhite\u200Bspace');
                 });
         });
     });

--- a/cypress/integration/utils/whitespace.js
+++ b/cypress/integration/utils/whitespace.js
@@ -26,6 +26,17 @@ describe('Whitespace options for commands yielding strings', function() {
             expect(this.ws('\t \r \n\xa0   Lorum ipsum dolor sit amet'))
                 .to.equal('Lorum ipsum dolor sit amet');
         });
+
+        it('removes zero-width whitespace', function() {
+            expect(this.ws('Lorum\u200Bipsum dol\uFEFFor sit amet'))
+                .to.equal('Lorumipsum dolor sit amet');
+
+            expect(this.ws('Lorum\u200Cips\uFEFFum dolor sit amet'))
+                .to.equal('Lorumipsum dolor sit amet');
+
+            expect(this.ws('Lorum\u200Dipsum dolor sit am\uFEFFet'))
+                .to.equal('Lorumipsum dolor sit amet');
+        });
     });
 
     context('mode = `keep-newline`', function() {
@@ -60,6 +71,17 @@ describe('Whitespace options for commands yielding strings', function() {
 
             expect(this.ws('\nLorum ipsum dolor sit amet'))
                 .to.equal('\nLorum ipsum dolor sit amet');
+        });
+
+        it('removes zero-width whitespace', function() {
+            expect(this.ws('Lorum\u200Bipsum dol\uFEFFor sit amet'))
+                .to.equal('Lorumipsum dolor sit amet');
+
+            expect(this.ws('Lorum\u200Cips\uFEFFum dolor sit amet'))
+                .to.equal('Lorumipsum dolor sit amet');
+
+            expect(this.ws('Lorum\u200Dipsum dolor sit am\uFEFFet'))
+                .to.equal('Lorumipsum dolor sit amet');
         });
     });
 

--- a/docs/attribute.md
+++ b/docs/attribute.md
@@ -93,13 +93,6 @@ By default all whitespace will be kept intact.
 
 ```javascript
 // yields "Extravagant Eagle"
-cy.get('div').attribute('data-attribute');
-```
-
-The default value of `whitespace` is `simplify` so the following yields the same.
-
-```javascript
-// yields "Extravagant Eagle"
 cy.get('div').attribute('data-attribute', { whitespace: 'simplify' });
 ```
 
@@ -111,6 +104,13 @@ cy.get('div').attribute('data-attribute', { whitespace: 'keep-newline' });
 ```
 
 #### Do not simplify whitespace (default)
+
+```javascript
+// yields " Extravagant  \n  Eagle            "
+cy.get('div').attribute('data-attribute');
+```
+
+The default value of `whitespace` is `keep` so the following yields the same.
 
 ```javascript
 // yields " Extravagant  \n  Eagle            "

--- a/docs/text.md
+++ b/docs/text.md
@@ -182,7 +182,7 @@ cy.get('.parent')
 To infinity and beyond!
 
 ```javascript
-// yields "Grandma Gazelle Mother Meerkat Father Fox Son Scorpion"
+// yields "Grandma Gazelle Mother Meerkat Son Scorpion Father Fox"
 cy.get('.grandparent')
   .text({ depth: Infinity });
 ```

--- a/src/text.js
+++ b/src/text.js
@@ -105,10 +105,8 @@ Cypress.Commands.add('text', { prevSubject: 'element' }, (element, options = {})
  * @return {string}
  */
 function getTextOfElement(element, depth) {
-    const zeroWidthSpace = '\u200B';
-
     const TAG_REPLACEMENT = {
-        'WBR': zeroWidthSpace,
+        'WBR': '\u200B',
         'BR': ' ',
     };
 

--- a/src/text.js
+++ b/src/text.js
@@ -118,11 +118,11 @@ function getTextOfElement(element, depth) {
             if (content.nodeType === Node.ELEMENT_NODE && content.nodeName === 'WBR') {
                 return text += zeroWidthSpace;
             }
-            if (text.endsWith(zeroWidthSpace)) {
-                return text += content.data.trim();
+            if (!text.endsWith(zeroWidthSpace)) {
+                text += ' ';
             }
-            text += ' ' + content.data.trim();
-        })
+            text += content.data.trim();
+        });
 
     if (depth > 0) {
         const children = element.children();

--- a/src/utils/whitespace.js
+++ b/src/utils/whitespace.js
@@ -3,9 +3,12 @@
  * @return {function}
  */
 export default function whitespace(mode) {
+    const zeroWidthWhitespace = /[\u200B-\u200D\uFEFF]/g;
+
     if (mode === 'simplify') {
         return (input) => {
             return input
+                .replace(zeroWidthWhitespace, '')
                 .replace(/\s+/g, ' ')
                 .trim();
         };
@@ -14,6 +17,7 @@ export default function whitespace(mode) {
     if (mode === 'keep-newline') {
         return (input) => {
             return input
+                .replace(zeroWidthWhitespace, '')
                 .replace(/[^\S\n]+/g, ' ')
                 .replace(/^[^\S\n]/g, '')
                 .replace(/[^\S\n]$/g, '')


### PR DESCRIPTION
Closes #46

This is a breaking change!

This removes zero-width whitespace when using a command with whitespace modes. This affects both `.text()` and `.attribute()`. Though I doubt anyone will run into issues with `.attribute()`.

More documentation is needed to tell people about the break.

- [x] Tests
- [x] Documentation
- [x] Type definitions
- [x] Ready for merge


## Changelog

### Breaking changes
- Whitespace handling in `.text()` and `.attribute()` has been changed to no longer consider zero-width whitespace to be whitespace in modes `{whitespace: 'simplify'}` and `{whitespace: 'keep-newline'}`. Mode `{whitespace: 'keep'}` has not changed.

  ```html
  <div>super\u200Bcalifragilistic\u200Bexpialidocious</div>
  ```
  ```javascript
  // Old situation
  cy.get('div')
    .text()
    .should('equal', 'super califragilistic expialidocious');
  ```
  ```javascript
  // New situation
  cy.get('div')
    .text()
    .should('equal', 'supercalifragilisticexpialidocious');
  ```

- When using `.text()` on elements containing the `<wbr>` tag: `<wbr>` is now considered a zero-width space and will thus be removed with whitespace `simplify` and `keep-newline`.

  ```html
  <div>super<wbr>califragilistic<wbr>expialidocious</div>
  ```
  ```javascript
  // Old situation
  cy.get('div')
    .text()
    .should('equal', 'super califragilistic expialidocious');
  ```
  ```javascript
  // New situation
  cy.get('div')
    .text()
    .should('equal', 'supercalifragilisticexpialidocious');
  ```


- When using `.text({ depth: Number })` the order of texts has been changed to better reflect what the user sees. It will now first traverse all the way to the deepest point, before going sideways. This will make `.text()` behave much better with inline styling and links.
 
  ```html
  <div class="parent">
      parent div top
      <div>
          child div
      </div>
      parent div middle
      <div>
          second-child div
      </div>
      parent div bottom
  </div>
  ```
  ```javascript
  // Old situation
  // Note how the first part of the string is the various parts of `div.parent`
  cy.get('parent')
    .text({ depth: 1 })
    .should('equal', 'parent div top parent div middle parent div bottom child div second-child div');
  ```
  ```javascript
  // New situation
  cy.get('div')
    .text({ depth: 1 })
    .should('equal', 'parent div top child div parent div middle second-child div parent div bottom');
  ```

  Inline text formatting:

  ```html
  <div>
      Text with <b>some</b> styling and <a href="...">a link</a>.
  </div>
  ```
  ```javascript
  // Old situation
  cy.get('div')
    .text({ depth: 1 })
    .should('equal', 'Text with styling and . some a link');
  ```
  ```javascript
  // New situation
  cy.get('div')
    .text({ depth: 1 })
    .should('equal', 'Text with some styling and a link.');
  ```
